### PR TITLE
Avoid precision errors in TSR

### DIFF
--- a/lib/estimators/TSR.js
+++ b/lib/estimators/TSR.js
@@ -57,7 +57,7 @@ module.exports = function (domain, range) {
   // Denominator i.e. determinant
   // It is zero iff domain[i] = domain[j] for every i and j in [0, n).
   // In other words, iff all the domain points are the same or there is only one domain point.
-  const det = N * a2 + N * b2 - a1 * a1 - b1 * b1
+  const det = N * a2 - a1 * a1 + N * b2 - b1 * b1
 
   if (Math.abs(det) < TOLERANCE) {
     // The domain points are the same.

--- a/test/estimators/TSR.test.js
+++ b/test/estimators/TSR.test.js
@@ -96,4 +96,17 @@ module.exports = (ts) => {
 
     t.end()
   })
+
+  ts.test(title + 'avoids precision errors', (t) => {
+    const dom = [{ x: 314.24933946532116, y: 807.8879779776474 }]
+    const ran = [{ x: 314.24933946532116, y: 824.4274168968749 }]
+
+    t.transformsEqual(
+      estimateTSR(dom, ran),
+      { a: 1, b: 0, x: ran[0].x - dom[0].x, y: ran[0].y - dom[0].y },
+      'simple translation, no scaling or rotation'
+    )
+
+    t.end()
+  })
 }


### PR DESCRIPTION
I'm using the TSR estimator for multitouch gestures that can be arbitrary number of points (something like `estimate('tsr', touchesBefore.map(clientPosition), touchesAfter.map(clientPosition))`). When doing this with some single-touch point sets, I found that the resulting transform had `a === b === 0` – confusing because a single pointer pan should always be a valid translation, no?

I looked into it – it looks like the specific points I was providing were causing a precision error when calculating `det`. Here's a test that fails on current `master`: https://github.com/davidisaaclee/nudged/blob/2594af5c79660ef805f8892b20c135151faf03e7/test/estimators/TSR.test.js#L100-L111

Some other valid solutions:
- I could round my inputs to more reasonable precisions
- I could switch to `T` estimator when I know I have one point

But I'd prefer not to think about that stuff! so here's a PR that fixes this by just switching the order of `det` expression so that the terms that probably will cancel each other out are next to each other. I don't fully get why it works, but it makes the test pass.

Thanks for the great library, I use it in almost every web app I make.